### PR TITLE
Ensure Geist font variables are applied to layout

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -22,9 +22,6 @@
   }
 }
 
-body {
-  font-family: Arial, Helvetica, sans-serif;
-} 
 .animation-delay-2000 {
   animation-delay: 2s;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -26,7 +26,7 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <body  className={inter.className}>
+      <body className={`${inter.className} ${geistSans.variable} ${geistMono.variable}`}>
         <Navbar />
         {children}
       </body>


### PR DESCRIPTION
## Summary
- remove the hard-coded body font declaration so the Geist fonts can drive global typography
- attach the Geist sans and mono font variables to the body element to expose the CSS variables

## Testing
- not run (next lint prompts for interactive configuration)

------
https://chatgpt.com/codex/tasks/task_e_68dea1fd6d308324bd3aa5c7ed20ec2c