### PR TITLE
Add dark mode toggle and enhance hero styling

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,49 +1,67 @@
+"use client";
+
 import Image from "next/image";
+import { useState } from "react";
 
 export default function Home() {
+  const [isDark, setIsDark] = useState(false);
+
   return (
-    <main className="relative min-h-screen overflow-hidden py-24 flex items-center justify-center px-4 bg-gradient-to-br from-slate-100 via-white to-slate-200 text-gray-900">
-      {/* Content */}
-      <div className="bg-white/40 backdrop-blur-md border border-white/20 shadow-lg rounded-xl p-10 max-w-3xl w-full text-center">
-        <h1 className="text-5xl font-extrabold mb-4">Mehul Sharma</h1>
-        <p className="text-xl text-gray-700 mb-6">
-          Software Engineer focused on building scalable backend systems and clean user experiences.
-        </p>
-
-        <div className="flex flex-col sm:flex-row gap-4 justify-center mt-6">
-          <a
-            href="/projects"
-            className="px-6 py-3 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 transition duration-300"
-          >
-            View Projects
-          </a>
-
-          <a
-          href="https://www.linkedin.com/in/mehul-sharma-1308861a0/"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="flex items-center gap-2 px-6 py-3 border border-indigo-600 text-indigo-600 rounded-md hover:bg-indigo-100 transition duration-300"
-          >
-          <Image
-            src="/mehul_linkedin.jpg"
-            alt="Mehul Sharma"
-            width={24}
-            height={24}
-            className="w-6 h-6 rounded-full object-cover"
-          />
-          <span className="text-sm font-medium">Linkedin</span>
-          </a>
-
-            
-          <a
-            href="/Mehul_Sharma_Resume.pdf"
-            download
-            className="px-6 py-3 border border-indigo-600 text-indigo-600 rounded-md hover:bg-indigo-100 transition duration-300"
-          >
-            Download Resume
-          </a>
+    <div className={isDark ? "dark" : ""}>
+      <main className="relative min-h-screen overflow-hidden py-24 flex items-center justify-center px-4 transition-colors duration-700 bg-gradient-to-br from-indigo-50 via-rose-50 to-slate-200 text-slate-900 dark:from-slate-950 dark:via-slate-900 dark:to-slate-950 dark:text-slate-100">
+        <div className="absolute inset-0 -z-10">
+          <div className="absolute inset-0 opacity-70 mix-blend-plus-lighter blur-3xl motion-safe:animate-aurora bg-[radial-gradient(circle_at_15%_20%,rgba(99,102,241,0.35),transparent_55%),_radial-gradient(circle_at_85%_15%,rgba(244,114,182,0.3),transparent_60%),_radial-gradient(circle_at_50%_80%,rgba(56,189,248,0.25),transparent_60%)] dark:bg-[radial-gradient(circle_at_20%_20%,rgba(129,140,248,0.35),transparent_55%),_radial-gradient(circle_at_80%_10%,rgba(14,165,233,0.25),transparent_60%),_radial-gradient(circle_at_50%_80%,rgba(34,197,94,0.25),transparent_60%)]" />
         </div>
-      </div>
-    </main>
+
+        <button
+          type="button"
+          onClick={() => setIsDark((prev) => !prev)}
+          className="absolute top-6 right-6 z-10 flex items-center gap-2 rounded-full border border-white/40 bg-white/50 px-4 py-2 text-sm font-medium text-slate-800 shadow-lg backdrop-blur-md transition-transform duration-300 hover:scale-105 hover:shadow-xl dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-100"
+        >
+          {isDark ? "🌞 Light" : "🌙 Dark"}
+        </button>
+
+        {/* Content */}
+        <div className="relative z-10 max-w-3xl w-full text-center rounded-2xl border border-white/30 bg-white/60 p-10 shadow-2xl backdrop-blur-xl transition-transform duration-500 ease-out hover:scale-[1.02] hover:shadow-[0_30px_80px_-40px_rgba(79,70,229,0.45)] dark:border-slate-700/60 dark:bg-slate-900/60 dark:shadow-[0_30px_90px_-50px_rgba(15,23,42,0.7)]">
+          <h1 className="text-5xl font-extrabold mb-4">Mehul Sharma</h1>
+          <p className="text-xl text-slate-700 dark:text-slate-300 mb-6">
+            Software Engineer focused on building scalable backend systems and clean user experiences.
+          </p>
+
+          <div className="flex flex-col sm:flex-row gap-4 justify-center mt-6">
+            <a
+              href="/projects"
+              className="px-6 py-3 bg-indigo-600 text-white rounded-md shadow-md transition-transform duration-300 hover:-translate-y-1 hover:shadow-xl hover:bg-indigo-500"
+            >
+              View Projects
+            </a>
+
+            <a
+              href="https://www.linkedin.com/in/mehul-sharma-1308861a0/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-2 px-6 py-3 rounded-md border border-indigo-500/80 text-indigo-600 shadow-md transition-transform duration-300 hover:-translate-y-1 hover:shadow-xl hover:border-indigo-400 hover:text-indigo-500 dark:border-indigo-300/70 dark:text-indigo-200 dark:hover:border-indigo-200 dark:hover:text-indigo-100"
+            >
+              <Image
+                src="/mehul_linkedin.jpg"
+                alt="Mehul Sharma"
+                width={24}
+                height={24}
+                className="w-6 h-6 rounded-full object-cover"
+              />
+              <span className="text-sm font-medium">LinkedIn</span>
+            </a>
+
+            <a
+              href="/Mehul_Sharma_Resume.pdf"
+              download
+              className="px-6 py-3 rounded-md border border-indigo-500/80 text-indigo-600 shadow-md transition-transform duration-300 hover:-translate-y-1 hover:shadow-xl hover:border-indigo-400 hover:text-indigo-500 dark:border-indigo-300/70 dark:text-indigo-200 dark:hover:border-indigo-200 dark:hover:text-indigo-100"
+            >
+              Download Resume
+            </a>
+          </div>
+        </div>
+      </main>
+    </div>
   );
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,16 +1,25 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  content: [
-    "./src/**/*.{js,ts,jsx,tsx}",
-  ],
+  darkMode: "class",
+  content: ["./src/**/*.{js,ts,jsx,tsx}"],
   theme: {
-  extend: {
-    colors: {
-      primary: '#6366f1',     // Indigo-500
-      secondary: '#f1f5f9',   // Slate-100
-      accent: '#0f172a',      // Slate-900
-            },
+    extend: {
+      colors: {
+        primary: "#6366f1", // Indigo-500
+        secondary: "#f1f5f9", // Slate-100
+        accent: "#0f172a", // Slate-900
+      },
+      keyframes: {
+        aurora: {
+          "0%": { transform: "translate3d(-5%, -5%, 0) scale(1)" },
+          "50%": { transform: "translate3d(5%, 8%, 0) scale(1.05)" },
+          "100%": { transform: "translate3d(-5%, -5%, 0) scale(1)" },
         },
+      },
+      animation: {
+        aurora: "aurora 18s ease-in-out infinite",
+      },
     },
-    plugins: [],
-}
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- refresh the hero background with layered gradients and a subtle animated aurora overlay
- add interactive hover states to the main highlight card and hero actions
- introduce a client-side dark mode toggle powered by Tailwind's class-based dark theme support

## Testing
- `npm run lint` *(fails: command prompts for interactive ESLint configuration in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68deab3247dc83249b2ad7c519725443