### PR TITLE
Fix resume PDF link

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -47,7 +47,7 @@ export default function Home() {
             </a>
 
             <a
-              href="/Mehul_Sharma_Resume.pdf"
+              href="/Mehul%20Sharma%20-%20Resume.pdf"
               download
               className="px-8 py-4 border-2 border-gray-600 dark:border-gray-400 text-gray-600 dark:text-gray-400 rounded-xl hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-all duration-300 transform hover:scale-105 font-semibold"
             >


### PR DESCRIPTION
## Summary
- update the resume download link to reference the correctly named PDF asset

## Testing
- `npm run dev` (manually verified the Download Resume button triggers the PDF download)


------
https://chatgpt.com/codex/tasks/task_e_68deb4606a308324a24802c15ba3f6ba