### PR TITLE
Enable Tailwind dark mode via class selector

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,16 +1,17 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: 'class',
   content: [
     "./src/**/*.{js,ts,jsx,tsx}",
   ],
   theme: {
-  extend: {
-    colors: {
-      primary: '#6366f1',     // Indigo-500
-      secondary: '#f1f5f9',   // Slate-100
-      accent: '#0f172a',      // Slate-900
-            },
-        },
+    extend: {
+      colors: {
+        primary: '#6366f1',     // Indigo-500
+        secondary: '#f1f5f9',   // Slate-100
+        accent: '#0f172a',      // Slate-900
+      },
     },
-    plugins: [],
+  },
+  plugins: [],
 }


### PR DESCRIPTION
## Summary
- enable Tailwind's class-based dark mode trigger
- clean up indentation for the theme color extension block

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68deb5bc6f848324b43a4c38a9f44a2e