### PR TITLE
Use dark class for theme variables

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -17,11 +17,9 @@
   --font-mono: var(--font-geist-mono);
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
+html.dark {
+  --background: #0a0a0a;
+  --foreground: #ededed;
 }
 
 /* Custom scrollbar styles */


### PR DESCRIPTION
## Summary
- replace the prefers-color-scheme media query with an `html.dark` rule so color variables follow the theme class
- ensure theme toggling relies on the `.dark` class rather than the OS preference

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68deb84cf8c88324aec7a3a9d71e578c