### PR TITLE
Enable class-based dark mode in Tailwind

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: 'class',
   content: [
     "./src/**/*.{js,ts,jsx,tsx}",
   ],


### PR DESCRIPTION
## Summary
- enable class-based dark mode in Tailwind configuration

## Testing
- `npm run build` *(fails: unable to fetch Google Fonts due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68deb99762348324a35c2fda09f36a3f